### PR TITLE
Allow messages from Reminder

### DIFF
--- a/src/bot-settings.js
+++ b/src/bot-settings.js
@@ -12,6 +12,11 @@ module.exports = {
     // eg. "!lunch ostrava" but emoji will still works "!lunch :ostrava:"
     useSimpeKeyWordWithCommand: true,
 
+    // Allow command in slack remnider
+    // Expected reminder strucutre "Reminder: message."
+    // eg. "/remind #ostrava-office @lunchbot at 11:00"
+    allowReminder: true,
+
     // Bot can reply in thread to not make mess in communication in the channel
     // Default is false,
     // when value is true, then all responses will be in new thread.

--- a/src/bot.js
+++ b/src/bot.js
@@ -50,6 +50,11 @@ class LunchBot extends Bot {
             return;
         }
 
+        // Remove reminder text from message
+        if (botSettings.allowReminder) {
+            text = this.removeReminderFromMessage(text)
+        }
+
         // Get message channel info
         const channel = this.getChannel(message);
 
@@ -75,6 +80,13 @@ class LunchBot extends Bot {
         });
     }
 
+    removeReminderFromMessage(text) {
+        if (text.startsWith('Reminder: ') && text.endsWith('.')) {
+            return text.slice(10, text.length - 1)
+        }
+        return text
+    }
+
     getChannel(message) {
         return this.channels.find(ch => ch.id === message.channel);
     }
@@ -83,8 +95,10 @@ class LunchBot extends Bot {
         if (botSettings.command || botSettings.useBotNameAsCommand) {
             if (botSettings.command && text.startsWith(botSettings.command)) {
                 text = text.slice(botSettings.command.length, text.length).trim();
-            } else if (botSettings.useBotNameAsCommand && text.startsWith(`<@${this.user.id}>`)) {
-                text = text.slice(this.user.id.length + 3, text.length).trim();
+            } else if (botSettings.useBotNameAsCommand &&
+                (text.startsWith(`<@${this.user.id}>`) || text.startsWith(`<@${this.user.id}|`))
+            ) {
+                text = text.slice(text.indexOf('>') + 1, text.length).trim()
             } else {
                 // Command or name are defined but message is not starting with it
                 return;


### PR DESCRIPTION
Add settings which allow parsing also reminder messages.
Reminder message is send by normal user (not bot!),
due to this lunchbot check text structure "Reminder: " +message +"." and remove it before message processing.
When message contains @lunchbot it's send as <@U13246|lunchbot>, so also name check was improved.